### PR TITLE
Update Windows executable

### DIFF
--- a/dist/config.json
+++ b/dist/config.json
@@ -1,21 +1,18 @@
 {
-	"stats_path": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\FPSAimTrainer\\FPSAimTrainer\\stats",
-	"sheet_id": "your_sheet_id_here",
-	"scenario_name_ranges": [
-		"Intermediate Requirements!E3:E20",
-		"Advanced Requirements!E3:E20"
-	],
-	"highscore_ranges": [
-		"Intermediate Requirements!G3:G20",
-		"Advanced Requirements!G3:G20"
-	],
-	"average_ranges": [
-		"Intermediate Requirements!M3:M20",
-		"Advanced Requirements!M3:M20"
-	],
-	"run_mode": "once",
-	"calculate_averages": true,
-	"num_of_runs_to_average": 5,
-	"polling_interval": 60,
-	"open_config": true
+    "stats_path": "path\\to\\Steam\\steamapps\\common\\FPSAimTrainer\\FPSAimTrainer\\stats",
+    "sheet_id": "1PWeiQVw22pYslSVTmfX7BqzFHWhSYejLxrRINuDlafU",
+    "scenario_name_ranges": [
+        "Progression Sheet!D3:D20"
+    ],
+    "highscore_ranges": [
+        "Progression Sheet!F3:F20"
+    ],
+    "average_ranges": [
+        "Progression Sheet!H3:H20"
+    ],
+    "run_mode": "once",
+    "calculate_averages": false,
+    "num_of_runs_to_average": 0,
+    "polling_interval": 60,
+    "open_config": true
 }

--- a/dist/logging.conf
+++ b/dist/logging.conf
@@ -1,0 +1,30 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler,fileHandler
+
+[formatters]
+keys=simpleFormatter,consoleFormatter
+
+[logger_root]
+level=NOTSET
+handlers=consoleHandler,fileHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=consoleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=FileHandler
+level=DEBUG
+formatter=simpleFormatter
+args=('debug.log', 'w')
+
+[formatter_simpleFormatter]
+format=%(asctime)s | %(levelname)s | %(name)s | %(message)s
+
+[formatter_consoleFormatter]
+format=%(asctime)s | %(message)s


### PR DESCRIPTION
This pull request is to share a compiled Windows binary that doesn't get blocked by Antivirus engines and runs cleaner scans in Virustotal.

The default bootloaders used to compile Python code using Pyinstaller get flagged by Antivirus engines leading to false positives.  This binary was compiled with a custom bootloader to avoid that problem.

Note - I had to copy the logging.conf file to the dist directory to get the executable to run properly.  There may be an alternative way to achieve that goal.

Fixes #3 