### PR TITLE
Fix kovaak and google sheet scenarios name mismatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,7 +176,7 @@ def update_kovaaks(config: dict, scens: dict, files: list, blacklist: dict) -> N
 
     # Process new runs to populate new_hs and new_avgs
     for f in files:
-        s = f[0:f.find(" - Challenge - ")].lower()
+        s = f[0:f.find(" - Challenge - ")].lower().strip()
         if s in scens:
             if s in blacklist.keys():
                 date = f[f.find(" - Challenge - ") + 15:]


### PR DESCRIPTION
Currently  `.strip()` and `.lower()` are applied to google sheet range values, https://github.com/VoltaicHQ/Progress-Sheet-Updater/blob/c2ad114af966968650d05edbe7fd701bc4c35f2d/sheets.py#L33

but while processing KovaaK scenarios names only `.lower()` is applied.

Scores for scenario `VT 1w5ts Intermediate ` (and may be for some others) will not be updated because of trailing whitespace at KovaaK scenario name.

Here is simple fix for that.